### PR TITLE
Add support for in-process worker

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 BullMQ integration for Nuxt. Comes with an API for the programmatic management of queues and workers. Offers its own user interface based on `@nuxt/ui`, which can be integrated as a component.
 
-This module offers a dedicated build process for running and scaling workers in seperate processes on the server. Nethertheless it is deep integrated with the Nuxt framework to achive a great developer usability.
+This module offers a dedicated build process for running and scaling workers in separate processes on the server. Nevertheless, it is deeply integrated with the Nuxt framework to achieve great developer usability.
 
 ## ✅ Status
 
-Currently in developing mode, wip.
+Currently in development mode, work in progress.
 
 ## 🚀 Usage
 
@@ -40,18 +40,16 @@ The queue UI components can be enabled by setting config `queue.ui` to true.
 }
 ```
 
-As the UI components are based on `@nuxt/ui`, you have to install this module seperatley and add it to `nuxt.config`.
+As the UI components are based on `@nuxt/ui`, it will be installed alongside.
 
 ```ts
 {
   modules: [
     'nuxt-queue'
-    '@nuxt/ui',
   ],
 }
 ```
 
-Since this module uses the `tailwindcss:config` hook, it must be registered before `@nuxt/ui`.
 
 Use the component in your application:
 
@@ -64,10 +62,12 @@ Use the component in your application:
 ```
 
 ## ROADMAP
-
-- Add more features to UI
-- Save memory by not loading queue instances in memory
-- Flow support + UI ([Vue Flow](https://vueflow.dev/))
+- Better dev runtime support for worker (check new files for in-process and sandboxed worker)
+- Add support for nuxt layers
+- Dev types for external workers
+- Test if it saves memory by not loading queue instances in memory
+- Add queue steps as own worker handler -> Programmable with auto UI
+- Add programmable flows for worker as UI and API ([Vue Flow](https://vueflow.dev/))
 
 
 ## ©️ License

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Use the component in your application:
 - Add support for nuxt layers
 - Dev types for external workers
 - Test if it saves memory by not loading queue instances in memory
-- Add queue steps as own worker handler -> Programmable with auto UI
+- Add queue steps as own worker handler (Programmable with auto UI)
 - Add programmable flows for worker as UI and API ([Vue Flow](https://vueflow.dev/))
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nuxt-queue",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Nuxt queue service based on Bullmq",
   "repository": "DevJoghurt/nuxt-fhir",
   "license": "MIT",

--- a/playground/queues/sandboxed/index.ts
+++ b/playground/queues/sandboxed/index.ts
@@ -1,4 +1,4 @@
-export default defineQueueWorker('bla', async (job) => {
+export default defineQueueWorker('sandboxed', async (job) => {
   job.log('Hello from bla worker')
   job.updateProgress(100)
   console.log('Hello from bla worker')

--- a/playground/queues/test.ts
+++ b/playground/queues/test.ts
@@ -18,7 +18,7 @@ async function wait(job: Job) {
 export default defineQueueWorker({
   name: 'test',
 }, async (job) => {
-  job.log('Hello from test worker')
+  job.log('Hello from sandboxed test worker')
   await wait(job)
   return {
     status: 'success',

--- a/playground/server/queues/inprocess.ts
+++ b/playground/server/queues/inprocess.ts
@@ -16,9 +16,9 @@ async function wait(job: Job) {
 }
 
 export default defineQueueWorker({
-  name: 'test',
+  name: 'inprocess',
 }, async (job) => {
-  job.log('Hello from test worker')
+  job.log('Hello from inprocess worker')
   await wait(job)
   return {
     status: 'success',

--- a/playground/server/queues/inprocess.ts
+++ b/playground/server/queues/inprocess.ts
@@ -18,7 +18,8 @@ async function wait(job: Job) {
 export default defineQueueWorker({
   name: 'inprocess',
 }, async (job) => {
-  job.log('Hello from inprocess worker')
+  const { runtimeDir } = useRuntimeConfig().queue
+  job.log('Hello from inprocess worker with runtime context: ' + runtimeDir)
   await wait(job)
   return {
     status: 'success',

--- a/src/builder/config.ts
+++ b/src/builder/config.ts
@@ -5,13 +5,12 @@ import type {
 import unimportPlugin from 'unimport/unplugin'
 import type { NitroOptions } from 'nitropack'
 import esbuild from 'rollup-plugin-esbuild'
-import { join } from 'node:path'
 import { nodeResolve } from '@rollup/plugin-node-resolve'
 import commonjs from '@rollup/plugin-commonjs'
 import json from '@rollup/plugin-json'
 import circularDependencies from 'rollup-plugin-circular-dependencies'
-import { externals, type NodeExternalsOptions } from './externals'
 import type { RegisteredWorker } from '../types'
+import { externals, type NodeExternalsOptions } from './externals'
 
 export type RollupConfig = RollupInputOptions & {
   output: RollupOutputOptions
@@ -39,7 +38,7 @@ export function getRollupConfig(registeredWorker: RegisteredWorker[], options: O
 
   const entryFiles = {} as EntryFiles
   for (const worker of registeredWorker) {
-    if(worker.runtype === 'in-process') {
+    if (worker.runtype === 'in-process') {
       continue
     }
     entryFiles[worker.name] = `${options.rootDir}/${worker.file}`

--- a/src/module.ts
+++ b/src/module.ts
@@ -5,6 +5,7 @@ import {
   createResolver,
   addServerScanDir,
   addServerImportsDir,
+  addServerImports,
   addImportsDir,
   addComponent,
   addComponentsDir,
@@ -29,7 +30,7 @@ declare module '@nuxt/schema' {
     queue: {
       runtimeDir: string
       redis: ModuleOptions['redis']
-      queues: Record<string, Omit<QueueOptions,'connection'>>
+      queues: Record<string, Omit<QueueOptions, 'connection'>>
       workers: RegisteredWorker[]
     }
   }
@@ -92,6 +93,13 @@ export default defineNuxtModule<ModuleOptions>({
       buildDir: nuxt.options.buildDir,
     })
 
+    // add in-process worker composable
+    addServerImports([{
+      name: 'useWorkerProcessor',
+      as: '$useWorkerProcessor',
+      from: resolve(nuxt.options.buildDir, 'inprocess-worker-composable'),
+    }])
+
     const runtimeConfig = nuxt.options.runtimeConfig
 
     runtimeConfig.queue = defu(runtimeConfig.queue || {}, {
@@ -106,7 +114,7 @@ export default defineNuxtModule<ModuleOptions>({
 
     // BUILD SANDBOXED WORKER for production
     nuxt.hook('nitro:build:public-assets', async (nitro) => {
-      if (workers.filter((w) => w.runtype === 'sandboxed').length === 0) return // no building if no entry files
+      if (workers.filter(w => w.runtype === 'sandboxed').length === 0) return // no building if no entry files
       // add worker directory
       mkdirSync(join(nitro.options.output.dir, 'worker'), {
         recursive: true,
@@ -124,7 +132,7 @@ export default defineNuxtModule<ModuleOptions>({
     // BUILD SANDBOXED WORKER ONLY IN DEV MODE
     if (nuxt.options.dev) {
       nuxt.hook('nitro:init', (nitro) => {
-        if (workers.filter((w) => w.runtype === 'sandboxed').length === 0) return // no building if no entry files
+        if (workers.filter(w => w.runtype === 'sandboxed').length === 0) return // no building if no entry files
         // add worker directory
         mkdirSync(join(nuxt.options.buildDir, 'worker'), {
           recursive: true,

--- a/src/module.ts
+++ b/src/module.ts
@@ -29,7 +29,7 @@ declare module '@nuxt/schema' {
     queue: {
       runtimeDir: string
       redis: ModuleOptions['redis']
-      queues: Record<string, QueueOptions>
+      queues: Record<string, Omit<QueueOptions,'connection'>>
       workers: RegisteredWorker[]
     }
   }
@@ -85,8 +85,9 @@ export default defineNuxtModule<ModuleOptions>({
     })
 
     // initialize worker and queues
-    const { entryFiles, queues, workers } = await initializeWorker({
+    const { queues, workers } = await initializeWorker({
       rootDir: nuxt.options.rootDir,
+      serverDir: nuxt.options.serverDir,
       workerDir: options?.dir || 'queues',
       buildDir: nuxt.options.buildDir,
     })
@@ -103,15 +104,16 @@ export default defineNuxtModule<ModuleOptions>({
     // start build process
     let rollupConfig = null as null | RollupConfig
 
-    // BUILD WORKER for production
+    // BUILD SANDBOXED WORKER for production
     nuxt.hook('nitro:build:public-assets', async (nitro) => {
-      if (!entryFiles) return // no building if no entry files
+      if (workers.filter((w) => w.runtype === 'sandboxed').length === 0) return // no building if no entry files
       // add worker directory
       mkdirSync(join(nitro.options.output.dir, 'worker'), {
         recursive: true,
       })
       // create build config
-      rollupConfig = getRollupConfig(entryFiles, {
+      rollupConfig = getRollupConfig(workers, {
+        rootDir: nuxt.options.rootDir,
         buildDir: nitro.options.output.serverDir,
         nitro: nitro.options,
       })
@@ -119,15 +121,16 @@ export default defineNuxtModule<ModuleOptions>({
       await buildWorker(rollupConfig)
     })
 
-    // BUILD WORKER ONLY IN DEV MODE
+    // BUILD SANDBOXED WORKER ONLY IN DEV MODE
     if (nuxt.options.dev) {
       nuxt.hook('nitro:init', (nitro) => {
-        if (!entryFiles) return // no building if no entry files
+        if (workers.filter((w) => w.runtype === 'sandboxed').length === 0) return // no building if no entry files
         // add worker directory
         mkdirSync(join(nuxt.options.buildDir, 'worker'), {
           recursive: true,
         })
-        rollupConfig = getRollupConfig(entryFiles, {
+        rollupConfig = getRollupConfig(workers, {
+          rootDir: nuxt.options.rootDir,
           buildDir: nuxt.options.buildDir,
           nitro: nitro.options,
         })

--- a/src/runtime/server/plugins/queue.ts
+++ b/src/runtime/server/plugins/queue.ts
@@ -4,6 +4,7 @@ import {
   $useWorker,
   useRuntimeConfig,
   defineNitroPlugin,
+  $useWorkerProcessor,
 } from '#imports'
 
 export default defineNitroPlugin(async (nitro) => {
@@ -11,7 +12,6 @@ export default defineNitroPlugin(async (nitro) => {
 
   const { initQueue, initQueueEvent, disconnect: disconnectQueues } = $useQueue()
 
-  // const { launchProcess, closeProcess } = $useWorkerProcess()
   const { createWorker, closeWorker } = $useWorker()
 
   const { queues, workers } = useRuntimeConfig().queue
@@ -25,11 +25,17 @@ export default defineNitroPlugin(async (nitro) => {
   }
 
   /**
-   *  Initialize sandboxed worker
+   *  Initialize worker
    */
   for (const worker of workers) {
-    if(worker.runtype === 'sandboxed'){
+    if (worker.runtype === 'sandboxed') {
       createWorker(worker.name, worker.processor)
+    }
+    if (worker.runtype === 'in-process') {
+      const processor = await $useWorkerProcessor(worker.name)
+      if (processor) {
+        createWorker(worker.name, processor)
+      }
     }
   }
 

--- a/src/runtime/server/plugins/queue.ts
+++ b/src/runtime/server/plugins/queue.ts
@@ -20,15 +20,17 @@ export default defineNitroPlugin(async (nitro) => {
    *  Initialize queues
    */
   for (const queueName in queues) {
-    initQueue(queueName, queues[queueName])
-    initQueueEvent(queueName, queues[queueName])
+    initQueue(queueName, queues[queueName].options)
+    initQueueEvent(queueName, queues[queueName].options)
   }
 
   /**
    *  Initialize sandboxed worker
    */
   for (const worker of workers) {
-    createWorker(worker.name, worker.script)
+    if(worker.runtype === 'sandboxed'){
+      createWorker(worker.name, worker.processor)
+    }
   }
 
   nitro.hooks.hook('close', async () => {

--- a/src/runtime/server/utils/useWorker.ts
+++ b/src/runtime/server/utils/useWorker.ts
@@ -10,7 +10,7 @@ type WorkerInstance = {
   id: string
   name: string
   processor: Worker
-  runtype: 'spawn' | 'worker' | 'intern'
+  runtype: 'spawn' | 'workerThreads' | 'intern'
 }
 
 export type WorkerOptions = Omit<BullmqWorkerOptions, 'connection' >
@@ -20,7 +20,7 @@ const workerInstances = [] as WorkerInstance[]
 export function $useWorker() {
   const logger = consola.create({}).withTag('QUEUE')
 
-  const getWorkerInstances = (identifier: string | null) => {
+  const getWorkerInstances = (identifier?: string) => {
     let resWorkerInstances = null
     if (typeof identifier === 'string') {
       resWorkerInstances = workerInstances.filter(w => w.name === identifier)
@@ -46,7 +46,7 @@ export function $useWorker() {
 
     if (typeof processor === 'string') {
       processor = resolveRuntimePath(processor)
-      runtype = options?.useWorkerThreads && options.useWorkerThreads === true ? 'worker' : 'spawn'
+      runtype = options?.useWorkerThreads && options.useWorkerThreads === true ? 'workerThreads' : 'spawn'
     }
 
     const connection = {
@@ -78,7 +78,7 @@ export function $useWorker() {
     logger.success(`Worker '${name}' with id '${worker.id}' started successfully`)
   }
 
-  const closeWorker = async (identifier: string | null) => {
+  const closeWorker = async (identifier?: string) => {
     const filteredWorkerInstances = getWorkerInstances(identifier)
     const cachedRemoveIndexes = [] as number[]
     for (const workerInstance of filteredWorkerInstances) {

--- a/src/templates.ts
+++ b/src/templates.ts
@@ -1,0 +1,32 @@
+import {
+  addTemplate,
+} from '@nuxt/kit'
+import { join } from 'pathe'
+import type { RegisteredWorker } from './types'
+
+const importFiles = (workers: RegisteredWorker[], cwd: string = 'file') =>
+  workers
+    .filter(worker => worker.runtype === 'in-process')
+    .map(
+      worker => `import ${worker.name} from '${join(cwd, worker.file.replace('.ts', ''))}';`,
+    ).join('\n')
+
+export const createInProcessWorkerComposable = (
+  workers: RegisteredWorker[],
+  cwd: string,
+) => {
+  const inProcessWorkerComposable = `
+${importFiles(workers, cwd)}
+const registeredWorkers = {${workers.filter(worker => worker.runtype === 'in-process').map(worker => worker.name).join(', ')}};
+
+export const useWorkerProcessor = async (worker: string) => {
+  return (typeof registeredWorkers[worker] === 'function') ? registeredWorkers[worker] : null;
+};
+`
+
+  addTemplate({
+    filename: 'inprocess-worker-composable.ts',
+    write: true,
+    getContents: () => inProcessWorkerComposable,
+  })
+}

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -2,13 +2,17 @@ import type {
   WorkerOptions as BullmqWorkerOptions,
   QueueOptions as BullmqQueueOptions } from 'bullmq'
 
-export type WorkerOptions = Omit<BullmqWorkerOptions, 'connection' | 'useWorkerThreads'>
+export type WorkerRuntype = 'sandboxed' | 'in-process'
+
+export type WorkerOptions = Omit<BullmqWorkerOptions, 'connection'>
 
 export type WorkerConfig = Record<string, WorkerOptions>
 
 export type RegisteredWorker = {
   name: string
-  script: string
+  processor: string
+  file: string
+  runtype: WorkerRuntype
   options: WorkerOptions
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,12 +3,94 @@ import { globby } from 'globby'
 import { useLogger } from '@nuxt/kit'
 import defu from 'defu'
 import type { WorkerConfig, WorkerOptions, RegisteredWorker } from './types'
-import type { QueueOptions } from './types.js'
+import type { QueueOptions, WorkerRuntype } from './types.js'
 
-type InitializeWorkerOptions = {
-  workerDir: string
-  rootDir: string
-  buildDir: string
+type WorkerConfigOptions = {
+  cwd: string;
+  workerDir: string;
+}
+
+/**
+ * Analyze worker files and create a meta config
+ * @param file
+ * @param runtype
+ * @param options
+ * @returns WorkerConfig | null
+ */
+async function createWorkerConfig(file: string, runtype: WorkerRuntype, options: WorkerConfigOptions) {
+  const logger = useLogger()
+
+  let generatedID = file.replace(`${options.workerDir}/`, '').split('.').slice(0, -1).join('.')
+  // check if file path has a folder -> generatedID must be split
+  if (generatedID.includes('/')) {
+    const fileNameArray = generatedID.split('/')
+    if (fileNameArray.length === 2 && fileNameArray[1] === 'index') {
+      generatedID = fileNameArray[0]
+    }
+    else {
+      // no worker entry -> check next one
+      return null
+    }
+  }
+
+  let mod = null
+
+  try {
+    mod = await loadFile(`${options.cwd}/${file}`)
+  }
+  catch (e) {
+    logger.error('Worker', e)
+    return null
+  }
+
+  if (mod.exports.default?.$type === 'function-call') {
+    let meta = mod.exports.default?.$args[0] || ''
+    if (typeof meta === 'string') {
+      meta = {
+        name: meta,
+      }
+    }
+    if (typeof meta === 'object') {
+      meta = defu(meta, {
+        name: meta.name || generatedID,
+      })
+    }
+      const workerConfigArgs = meta as WorkerConfig
+      const workerConfig = defu({
+        name: meta.name,
+        processor: (runtype==='sandboxed') ? `${meta.name}.js` : 'function',
+        file,
+        runtype,
+        options: {
+          ...workerConfigArgs.options,
+        },
+      }, {
+        options: {
+          autorun: true,
+          concurrency: 1,
+          drainDelay: 5,
+          lockDuration: 30000,
+          maxStalledCount: 1,
+          runRetryDelay: 15000,
+          skipLockRenewal: false,
+          skipStalledCheck: false,
+          skipVersionCheck: false,
+          useWorkerThreads: false,
+          stalledInterval: 30000,
+        },
+      })
+      return workerConfig
+  }
+  else {
+    logger.error('Worker:', file, 'Found no default export. Please use export default defineWorker() syntax.')
+  }
+}
+
+type WorkerInitializeOptions = {
+  workerDir: string;
+  serverDir: string;
+  rootDir: string;
+  buildDir: string;
 }
 
 /**
@@ -19,104 +101,54 @@ type InitializeWorkerOptions = {
  * @returns RegisteredWorker[]
  *
  */
-export async function initializeWorker(options: InitializeWorkerOptions) {
+export async function initializeWorker(options: WorkerInitializeOptions) {
   const logger = useLogger()
 
-  // scan files and find worker entry files
-  const files = await globby(`${options.workerDir}/**/*.{ts,js,mjs}`, {
+  const queues = {} as Record<string, QueueOptions>
+  const registeredWorker = [] as RegisteredWorker[]
+
+  // scan sandboxed worker files and find worker entry files
+  const sandboxedFiles = await globby(`${options.workerDir}/**/*.{ts,js,mjs}`, {
     cwd: options.rootDir,
     deep: 2,
   })
-
-  let entryFiles = null as Record<string, string> | null
-  const queues = {} as Record<string, QueueOptions>
-  const registeredWorker = [] as RegisteredWorker[]
   // read worker configuration and write it as meta config file
-  const workerConfig = {} as WorkerConfig
-  for (const file of files) {
-    let generatedID = file.replace(`${options.workerDir}/`, '').split('.').slice(0, -1).join('.')
-    // check if file path has a folder -> generatedID must be split
-    if (generatedID.includes('/')) {
-      const fileNameArray = generatedID.split('/')
-      if (fileNameArray.length === 2 && fileNameArray[1] === 'queue') {
-        generatedID = fileNameArray[0]
-      }
-      else {
-        // no worker entry -> check next one
-        continue
+  for (const file of sandboxedFiles) {
+    const meta = await createWorkerConfig(file, 'sandboxed', {
+      cwd: options.rootDir,
+      workerDir: options.workerDir,
+    })
+    if(meta){
+      registeredWorker.push(meta)
+      // create minimal queue config
+      queues[meta.name] = {
+        origin: 'local',
       }
     }
+  }
 
-    let mod = null
-
-    try {
-      mod = await loadFile(`${options.rootDir}/${file}`)
-    }
-    catch (e) {
-      logger.error('Worker', e)
-      continue
-    }
-
-    if (mod.exports.default?.$type === 'function-call') {
-      let meta = mod.exports.default?.$args[0] || ''
-      if (typeof meta === 'string') {
-        meta = {
-          name: meta,
-        }
+  // scan in-process worker files and find worker entry files
+  const inProcessFiles = await globby(`${options.workerDir}/**/*.{ts,js,mjs}`, {
+    cwd: options.serverDir,
+    deep: 2,
+  })
+  for (const file of inProcessFiles) {
+    const meta = await createWorkerConfig(file, 'in-process', {
+      cwd: options.serverDir,
+      workerDir: options.workerDir,
+    })
+    if(meta){
+      registeredWorker.push(meta)
+      // create minimal queue config
+      queues[meta.name] = {
+        origin: 'local',
       }
-      if (typeof meta === 'object') {
-        meta = defu(meta, {
-          name: meta.name || generatedID,
-        })
-      }
-      const workerConfigArgs = meta as WorkerConfig
-      if (typeof workerConfig[meta.name] === 'undefined') {
-        workerConfig[meta.name] = workerConfigArgs
-        const workerDefaults = {
-          autorun: true,
-          concurrency: 1,
-          drainDelay: 5,
-          lockDuration: 30000,
-          maxStalledCount: 1,
-          runRetryDelay: 15000,
-          skipLockRenewal: false,
-          skipStalledCheck: false,
-          skipVersionCheck: false,
-          stalledInterval: 30000,
-        } as WorkerOptions
-
-        entryFiles = entryFiles || {}
-        entryFiles[meta.name] = `${options.rootDir}/${file}`
-
-        registeredWorker.push(defu({
-          name: meta.name,
-          script: `${meta.name}.js`,
-          options: {
-            ...workerConfigArgs,
-          },
-        }, {
-          options: {
-            ...workerDefaults,
-          },
-        }))
-        // create queue config
-        queues[meta.name] = {
-          origin: 'local',
-        }
-      }
-      else {
-        logger.error(`Worker [${meta.name}]`, `Worker already exists. Please change the worker file name.`)
-      }
-    }
-    else {
-      logger.error('Worker:', file, 'Found no default export. Please use export default defineWorker() syntax.')
     }
   }
 
   logger.success('Initialized worker:', registeredWorker.map(w => w.name))
 
   return {
-    entryFiles,
     queues,
     workers: registeredWorker,
   }


### PR DESCRIPTION
Added support for in-process workers. 
Previously, only sandboxed workers were supported. This enhancement provides flexibility by allowing tasks to run directly in the main process, improving performance and reducing overhead for specific use cases.